### PR TITLE
Add little wrapper around prometheus mustregister

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,19 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MustRegister is a wrapper around prometheus.MustRegister that attempts a
+// basic retry. We need this for the retry loop in the main server entrypoint
+// which can retry quickly if postgres is not available.
+func MustRegister(c prometheus.Collector) {
+	err := prometheus.Register(c)
+	if err != nil {
+		if prometheus.Unregister(c) {
+			prometheus.MustRegister(c)
+		} else {
+			panic(err)
+		}
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ import (
 	goji "goji.io"
 	pat "goji.io/pat"
 
+	"github.com/DECODEproject/iotstore/pkg/metrics"
 	"github.com/DECODEproject/iotstore/pkg/postgres"
 	"github.com/DECODEproject/iotstore/pkg/rpc"
 	"github.com/DECODEproject/iotstore/pkg/version"
@@ -35,7 +36,7 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(buildInfo)
+	metrics.MustRegister(buildInfo)
 }
 
 // Config is a struct used to pass in configuration from the calling task


### PR DESCRIPTION
This is to deal with an issue that I've seen sometimes where the server
start command retries a couple of times waiting for postgres to become
available.